### PR TITLE
181 bugfix save state failed inno prog input view

### DIFF
--- a/app/src/main/res/layout/fragment_project_details.xml
+++ b/app/src/main/res/layout/fragment_project_details.xml
@@ -73,8 +73,9 @@
         <com.innoprog.android.uikit.InnoProgInputView
             android:id="@+id/Description"
             android:layout_width="0dp"
-            android:layout_height="134dp"
+            android:layout_height="wrap_content"
             android:layout_marginTop="@dimen/margin_8"
+            app:minHeightEditText="134dp"
             app:label="@string/descriptions"
             app:layout_constraintEnd_toStartOf="@id/guidelineEnd"
             app:layout_constraintStart_toEndOf="@id/guidelineStart"

--- a/uikit/src/main/java/com/innoprog/android/uikit/InnoProgInputView.kt
+++ b/uikit/src/main/java/com/innoprog/android/uikit/InnoProgInputView.kt
@@ -12,14 +12,14 @@ import android.util.AttributeSet
 import android.view.View
 import android.view.View.OnFocusChangeListener
 import android.view.inputmethod.InputMethodManager
-import android.widget.EditText
 import android.widget.ImageView
 import android.widget.TextView
 import androidx.appcompat.content.res.AppCompatResources
 import androidx.constraintlayout.widget.ConstraintLayout
-import androidx.constraintlayout.widget.ConstraintSet
 import androidx.core.content.ContextCompat.getDrawable
-import androidx.transition.TransitionManager
+import androidx.core.view.isVisible
+import com.google.android.material.textfield.TextInputEditText
+import com.google.android.material.textfield.TextInputLayout
 import com.innoprog.android.uikit.ext.applyStyleable
 
 class InnoProgInputView @JvmOverloads constructor(
@@ -33,9 +33,9 @@ class InnoProgInputView @JvmOverloads constructor(
 ) {
     private var state: InnoProgInputViewState = InnoProgInputViewState.INACTIVE
 
-    private val editTextView by lazy { findViewById<EditText>(R.id.edit_text) }
+    private val tilEdit by lazy { findViewById<TextInputLayout>(R.id.til_edit) }
+    private val editTextView by lazy { findViewById<TextInputEditText>(R.id.edit_text) }
     private val captionTextView by lazy { findViewById<TextView>(R.id.caption) }
-    private val emptyHintTextView by lazy { findViewById<TextView>(R.id.hint_empty) }
     private val leftIcon by lazy { findViewById<ImageView>(R.id.left_icon) }
     private val rightIcon by lazy { findViewById<ImageView>(R.id.right_icon) }
     private val backgroundEditTextView by lazy { findViewById<ConstraintLayout>(R.id.background_edit_text_view) }
@@ -45,12 +45,6 @@ class InnoProgInputView @JvmOverloads constructor(
             context,
             R.drawable.inno_prog_input_view_background
         ) as LayerDrawable
-    }
-
-    private val constraintSet by lazy {
-        ConstraintSet().apply {
-            clone(backgroundEditTextView)
-        }
     }
 
     private val focusChangeListener by lazy {
@@ -103,9 +97,13 @@ class InnoProgInputView @JvmOverloads constructor(
 
             captionTextView.text = getString(R.styleable.InnoProgInputView_caption)
             leftIcon.setImageDrawable(getDrawable(R.styleable.InnoProgInputView_left_icon))
+            leftIcon.isVisible = leftIcon.drawable != null
             rightIcon.setImageDrawable(getDrawable(R.styleable.InnoProgInputView_right_icon))
-            emptyHintTextView.text = getString(R.styleable.InnoProgInputView_label)
+
             getString(R.styleable.InnoProgInputView_text)?.let { setText(it) }
+            editTextView.minHeight =
+                getDimensionPixelSize(R.styleable.InnoProgInputView_minHeightEditText, 0)
+            tilEdit.hint = getString(R.styleable.InnoProgInputView_label)
         }
 
         isFocusable = true
@@ -114,15 +112,7 @@ class InnoProgInputView @JvmOverloads constructor(
         this@InnoProgInputView.onFocusChangeListener = focusChangeListener
 
         editTextView.onFocusChangeListener = OnFocusChangeListener { _, hasFocus ->
-            if (hasFocus) {
-                showHintFilled()
-                renderState(InnoProgInputViewState.FOCUSED)
-            } else {
-                if (editTextView.text.isNullOrEmpty()) {
-                    showHintEmpty()
-                }
-                renderState(state)
-            }
+            renderState(state)
         }
     }
 
@@ -140,6 +130,7 @@ class InnoProgInputView @JvmOverloads constructor(
 
     fun setRightIcon(src: Int) {
         rightIcon.setImageDrawable(getDrawable(context, src))
+        rightIcon.isVisible = rightIcon.drawable != null
     }
 
     override fun onSaveInstanceState(): Parcelable {
@@ -198,47 +189,6 @@ class InnoProgInputView @JvmOverloads constructor(
         inputManager.showSoftInput(editTextView, 0)
     }
 
-    private fun showHintEmpty() {
-        emptyHintTextView.textSize = SP_16
-
-        constraintSet.connect(
-            R.id.hint_empty,
-            ConstraintSet.TOP,
-            R.id.left_icon,
-            ConstraintSet.TOP
-        )
-        constraintSet.connect(
-            R.id.hint_empty,
-            ConstraintSet.BOTTOM,
-            R.id.left_icon,
-            ConstraintSet.BOTTOM
-        )
-
-        TransitionManager.beginDelayedTransition(backgroundEditTextView)
-        constraintSet.applyTo(backgroundEditTextView)
-    }
-
-    private fun showHintFilled() {
-        emptyHintTextView.textSize = SP_12
-
-        constraintSet.connect(
-            R.id.hint_empty,
-            ConstraintSet.TOP,
-            ConstraintSet.PARENT_ID,
-            ConstraintSet.TOP
-        )
-        constraintSet.clear(R.id.hint_empty, ConstraintSet.BOTTOM)
-
-        constraintSet.setMargin(
-            R.id.hint_empty,
-            ConstraintSet.TOP,
-            resources.getDimensionPixelSize(R.dimen.margin_5)
-        )
-
-        TransitionManager.beginDelayedTransition(backgroundEditTextView)
-        constraintSet.applyTo(backgroundEditTextView)
-    }
-
     fun setLeftIconClickListener(onClickListener: OnClickListener) {
         leftIcon.setOnClickListener(onClickListener)
     }
@@ -255,13 +205,8 @@ class InnoProgInputView @JvmOverloads constructor(
         return editTextView.text.toString()
     }
 
-    fun setHintText(text: String) {
-        emptyHintTextView.text = text
-    }
-
     fun setText(text: String) {
         if (text.isNotBlank()) {
-            showHintFilled()
             editTextView.setText(text)
         }
     }
@@ -277,11 +222,6 @@ class InnoProgInputView @JvmOverloads constructor(
     private companion object {
         const val FULL_VISIBLE = 1f
         const val VISIBILITY_40_PERCENT = 0.4f
-
-        const val SP_12 = 12f
-        const val SP_16 = 16f
-
-        const val KEY_SUPER_STATE = "superState"
     }
 }
 

--- a/uikit/src/main/java/com/innoprog/android/uikit/InnoProgInputView.kt
+++ b/uikit/src/main/java/com/innoprog/android/uikit/InnoProgInputView.kt
@@ -3,9 +3,12 @@ package com.innoprog.android.uikit
 import android.content.Context
 import android.graphics.Color
 import android.graphics.drawable.LayerDrawable
+import android.os.Parcel
+import android.os.Parcelable
 import android.text.TextWatcher
 import android.text.method.TransformationMethod
 import android.util.AttributeSet
+import android.view.View
 import android.view.View.OnFocusChangeListener
 import android.view.inputmethod.InputMethodManager
 import android.widget.EditText
@@ -135,6 +138,22 @@ class InnoProgInputView @JvmOverloads constructor(
         rightIcon.setImageDrawable(getDrawable(context, src))
     }
 
+    override fun onSaveInstanceState(): Parcelable? {
+        val superState = super.onSaveInstanceState()
+        val savedState = SavedState(superState)
+        savedState.text = editTextView.text.toString()
+        return savedState
+    }
+
+    override fun onRestoreInstanceState(state: Parcelable?) {
+        if (state !is SavedState) {
+            super.onRestoreInstanceState(state)
+            return
+        }
+        super.onRestoreInstanceState(state.superState)
+        editTextView.setText(state.text)
+    }
+
     fun renderState(state: InnoProgInputViewState) {
         when (state) {
             InnoProgInputViewState.INACTIVE -> {
@@ -259,5 +278,33 @@ class InnoProgInputView @JvmOverloads constructor(
 
         const val SP_12 = 12f
         const val SP_16 = 16f
+    }
+}
+
+private class SavedState : View.BaseSavedState {
+    var text: String? = null
+
+    constructor(superState: Parcelable?) : super(superState)
+
+    private constructor(`in`: Parcel) : super(`in`) {
+        text = `in`.readString()
+    }
+
+    override fun writeToParcel(out: Parcel, flags: Int) {
+        super.writeToParcel(out, flags)
+        out.writeString(text)
+    }
+
+    companion object {
+        @JvmField
+        val CREATOR: Parcelable.Creator<SavedState> = object : Parcelable.Creator<SavedState> {
+            override fun createFromParcel(`in`: Parcel): SavedState {
+                return SavedState(`in`)
+            }
+
+            override fun newArray(size: Int): Array<SavedState?> {
+                return arrayOfNulls(size)
+            }
+        }
     }
 }

--- a/uikit/src/main/java/com/innoprog/android/uikit/InnoProgInputView.kt
+++ b/uikit/src/main/java/com/innoprog/android/uikit/InnoProgInputView.kt
@@ -3,6 +3,7 @@ package com.innoprog.android.uikit
 import android.content.Context
 import android.graphics.Color
 import android.graphics.drawable.LayerDrawable
+import android.os.Bundle
 import android.os.Parcel
 import android.os.Parcelable
 import android.text.TextWatcher
@@ -67,6 +68,9 @@ class InnoProgInputView @JvmOverloads constructor(
             R.layout.inno_prog_input_view,
             this
         )
+
+        editTextView.id = View.generateViewId()
+
         attrs?.applyStyleable(context, R.styleable.InnoProgInputView) {
 
             layerDrawable.findDrawableByLayerId(R.id.rectangle_background)
@@ -138,20 +142,18 @@ class InnoProgInputView @JvmOverloads constructor(
         rightIcon.setImageDrawable(getDrawable(context, src))
     }
 
-    override fun onSaveInstanceState(): Parcelable? {
-        val superState = super.onSaveInstanceState()
-        val savedState = SavedState(superState)
-        savedState.text = editTextView.text.toString()
-        return savedState
+    override fun onSaveInstanceState(): Parcelable {
+        val superState = super.onSaveInstanceState() ?: Bundle()
+        return SavedState(superState).apply {
+            text = editTextView.text.toString()
+        }
     }
 
     override fun onRestoreInstanceState(state: Parcelable?) {
-        if (state !is SavedState) {
-            super.onRestoreInstanceState(state)
-            return
-        }
-        super.onRestoreInstanceState(state.superState)
-        editTextView.setText(state.text)
+        (state as? SavedState)?.let {
+            editTextView.setText(it.text)
+            super.onRestoreInstanceState(it.superState)
+        } ?: super.onRestoreInstanceState(state)
     }
 
     fun renderState(state: InnoProgInputViewState) {
@@ -278,6 +280,8 @@ class InnoProgInputView @JvmOverloads constructor(
 
         const val SP_12 = 12f
         const val SP_16 = 16f
+
+        const val KEY_SUPER_STATE = "superState"
     }
 }
 
@@ -286,8 +290,8 @@ private class SavedState : View.BaseSavedState {
 
     constructor(superState: Parcelable?) : super(superState)
 
-    private constructor(`in`: Parcel) : super(`in`) {
-        text = `in`.readString()
+    private constructor(inParcel: Parcel) : super(inParcel) {
+        text = inParcel.readString()
     }
 
     override fun writeToParcel(out: Parcel, flags: Int) {

--- a/uikit/src/main/res/layout/inno_prog_input_view.xml
+++ b/uikit/src/main/res/layout/inno_prog_input_view.xml
@@ -4,6 +4,7 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
+    tools:background="@android:color/darker_gray"
     tools:parentTag="androidx.constraintlayout.widget.ConstraintLayout">
 
     <androidx.constraintlayout.widget.ConstraintLayout
@@ -29,40 +30,69 @@
             app:layout_constraintTop_toTopOf="parent"
             tools:src="@drawable/ic_placeholder" />
 
-        <TextView
-            android:id="@+id/hint_empty"
-            style="@style/TextBody_1"
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:layout_marginStart="8dp"
-            android:layout_marginTop="@dimen/margin_14"
-            android:layout_marginEnd="8dp"
-            android:backgroundTint="@android:color/transparent"
-            android:singleLine="true"
-            android:textColor="@color/text_secondary"
-            android:textSize="16sp"
-            app:layout_constraintEnd_toStartOf="@+id/right_icon"
-            app:layout_constraintStart_toEndOf="@+id/left_icon"
-            app:layout_constraintTop_toTopOf="parent"
-            tools:text="Label" />
+        <!--        <TextView-->
+        <!--            android:id="@+id/hint_empty"-->
+        <!--            style="@style/TextBody_1"-->
+        <!--            android:layout_width="0dp"-->
+        <!--            android:layout_height="wrap_content"-->
+        <!--            android:layout_marginStart="8dp"-->
+        <!--            android:layout_marginTop="@dimen/margin_14"-->
+        <!--            android:layout_marginEnd="8dp"-->
+        <!--            android:backgroundTint="@android:color/transparent"-->
+        <!--            android:singleLine="true"-->
+        <!--            android:textColor="@color/text_secondary"-->
+        <!--            android:textSize="16sp"-->
+        <!--            android:visibility="gone"-->
+        <!--            app:layout_constraintEnd_toStartOf="@+id/right_icon"-->
+        <!--            app:layout_constraintStart_toEndOf="@+id/left_icon"-->
+        <!--            app:layout_constraintTop_toTopOf="parent"-->
+        <!--            tools:text="Label" />-->
 
-        <EditText
-            android:id="@+id/edit_text"
-            style="@style/TextBody_1"
+        <!--        <EditText-->
+        <!--            android:id="@+id/edit_text"-->
+        <!--            style="@style/TextBody_1"-->
+        <!--            android:layout_width="0dp"-->
+        <!--            android:layout_height="wrap_content"-->
+        <!--            android:layout_marginStart="@dimen/margin_8"-->
+        <!--            android:layout_marginBottom="@dimen/margin_8"-->
+        <!--            android:background="@android:color/transparent"-->
+        <!--            android:gravity="top|start"-->
+        <!--            android:textColor="@color/text_primary"-->
+        <!--            android:textCursorDrawable="@null"-->
+        <!--            app:layout_constraintBottom_toBottomOf="parent"-->
+        <!--            app:layout_constraintEnd_toStartOf="@+id/right_icon"-->
+        <!--            app:layout_constraintHeight_min="wrap"-->
+        <!--            app:layout_constraintStart_toEndOf="@id/left_icon"-->
+        <!--            app:layout_constraintTop_toTopOf="parent"-->
+        <!--            tools:text="Filled text" />-->
+
+        <com.google.android.material.textfield.TextInputLayout xmlns:android="http://schemas.android.com/apk/res/android"
+            xmlns:app="http://schemas.android.com/apk/res-auto"
+            android:id="@+id/til_edit"
+            style="@style/Widget.MaterialComponents.TextInputLayout.FilledBox"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
+            android:layout_marginVertical="@dimen/margin_8"
             android:layout_marginStart="@dimen/margin_8"
-            android:layout_marginBottom="@dimen/margin_8"
             android:background="@android:color/transparent"
-            android:gravity="top|start"
-            android:textColor="@color/text_primary"
-            android:textCursorDrawable="@null"
-            app:layout_constraintBottom_toBottomOf="parent"
+            android:hint="Your hint"
+            app:boxBackgroundMode="none"
             app:layout_constraintEnd_toStartOf="@+id/right_icon"
-            app:layout_constraintHeight_min="wrap"
+            app:layout_constraintBottom_toBottomOf="@+id/background_edit_text_view"
             app:layout_constraintStart_toEndOf="@id/left_icon"
-            app:layout_constraintTop_toBottomOf="@+id/hint_empty"
-            tools:text="Filled text" />
+            app:layout_constraintTop_toTopOf="@+id/background_edit_text_view">
+
+            <com.google.android.material.textfield.TextInputEditText
+                android:id="@+id/edit_text"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:background="@android:color/transparent"
+                android:gravity="top|start"
+                android:paddingStart="8dp"
+                android:paddingTop="5dp"
+                android:textColor="@color/text_primary"
+                android:textCursorDrawable="@null" />
+        </com.google.android.material.textfield.TextInputLayout>
 
         <ImageView
             android:id="@+id/right_icon"

--- a/uikit/src/main/res/layout/inno_prog_input_view.xml
+++ b/uikit/src/main/res/layout/inno_prog_input_view.xml
@@ -30,42 +30,6 @@
             app:layout_constraintTop_toTopOf="parent"
             tools:src="@drawable/ic_placeholder" />
 
-        <!--        <TextView-->
-        <!--            android:id="@+id/hint_empty"-->
-        <!--            style="@style/TextBody_1"-->
-        <!--            android:layout_width="0dp"-->
-        <!--            android:layout_height="wrap_content"-->
-        <!--            android:layout_marginStart="8dp"-->
-        <!--            android:layout_marginTop="@dimen/margin_14"-->
-        <!--            android:layout_marginEnd="8dp"-->
-        <!--            android:backgroundTint="@android:color/transparent"-->
-        <!--            android:singleLine="true"-->
-        <!--            android:textColor="@color/text_secondary"-->
-        <!--            android:textSize="16sp"-->
-        <!--            android:visibility="gone"-->
-        <!--            app:layout_constraintEnd_toStartOf="@+id/right_icon"-->
-        <!--            app:layout_constraintStart_toEndOf="@+id/left_icon"-->
-        <!--            app:layout_constraintTop_toTopOf="parent"-->
-        <!--            tools:text="Label" />-->
-
-        <!--        <EditText-->
-        <!--            android:id="@+id/edit_text"-->
-        <!--            style="@style/TextBody_1"-->
-        <!--            android:layout_width="0dp"-->
-        <!--            android:layout_height="wrap_content"-->
-        <!--            android:layout_marginStart="@dimen/margin_8"-->
-        <!--            android:layout_marginBottom="@dimen/margin_8"-->
-        <!--            android:background="@android:color/transparent"-->
-        <!--            android:gravity="top|start"-->
-        <!--            android:textColor="@color/text_primary"-->
-        <!--            android:textCursorDrawable="@null"-->
-        <!--            app:layout_constraintBottom_toBottomOf="parent"-->
-        <!--            app:layout_constraintEnd_toStartOf="@+id/right_icon"-->
-        <!--            app:layout_constraintHeight_min="wrap"-->
-        <!--            app:layout_constraintStart_toEndOf="@id/left_icon"-->
-        <!--            app:layout_constraintTop_toTopOf="parent"-->
-        <!--            tools:text="Filled text" />-->
-
         <com.google.android.material.textfield.TextInputLayout xmlns:android="http://schemas.android.com/apk/res/android"
             xmlns:app="http://schemas.android.com/apk/res-auto"
             android:id="@+id/til_edit"

--- a/uikit/src/main/res/values/attrs.xml
+++ b/uikit/src/main/res/values/attrs.xml
@@ -13,6 +13,7 @@
         <attr name="caption" format="string" />
         <attr name="left_icon" format="reference" />
         <attr name="right_icon" format="reference" />
+        <attr name="minHeightEditText" format="dimension" />
     </declare-styleable>
 
     <declare-styleable name="LikeCustomView">


### PR DESCRIPTION
Поработал над кастом вью InnoProgInputView, сделал ПР:
- добавил предопределенные методы для работы с состоянием вьюшки
- решил проблему сохранения состояния последней добавленной вью (распространялось состояние на всех)
- убрал EditText, добавил TextInputLayout и TextInputEditText. Анимации и внешний вид стали как в Material Design. Оставил пока без изменений картинки, но в теории их тоже можно убрать, просто это дополнительное время, пока работает и так (там нужно тогда переделывать логику и реализацию "глаза" в пароле и может что-то ещё)
- Добавил параметр app:minHeightEditText (в dp), для возможности задать минимально отображаемую начальную высоту. Применил пока только для поля Описание на экране fragment_project_details